### PR TITLE
Select unsealed instance

### DIFF
--- a/service/auth_github.go
+++ b/service/auth_github.go
@@ -28,7 +28,7 @@ type GithubLoginData struct {
 // GithubLogin performs a standard Github authentication and initializes the vaultClient with the resulting token.
 func (s *VaultService) GithubLogin(data GithubLoginData) error {
 	// Perform login
-	vaultClient, err := s.newClient()
+	vaultClient, err := s.newUnsealedClient()
 	if err != nil {
 		return maskAny(err)
 	}

--- a/service/auth_server.go
+++ b/service/auth_server.go
@@ -52,7 +52,7 @@ func (s *VaultService) ServerLogin(data ServerLoginData) error {
 
 	// Perform step 1 login
 	s.log.Debug("Step 1 login")
-	vaultClient, err := s.newClient()
+	vaultClient, err := s.newUnsealedClient()
 	if err != nil {
 		return maskAny(err)
 	}

--- a/service/cluster.go
+++ b/service/cluster.go
@@ -34,7 +34,7 @@ type Cluster struct {
 }
 
 func (vs *VaultService) Cluster() (*Cluster, error) {
-	vaultClient, err := vs.newClient()
+	vaultClient, err := vs.newUnsealedClient()
 	if err != nil {
 		return nil, maskAny(err)
 	}

--- a/service/extract.go
+++ b/service/extract.go
@@ -30,7 +30,7 @@ func (s *VaultService) extractSecret(secretPath, secretField string) (string, er
 
 	// Load secret
 	s.log.Infof("Read %s#%s", secretPath, secretField)
-	vaultClient, err := s.newClient()
+	vaultClient, err := s.newUnsealedClient()
 	if err != nil {
 		return "", maskAny(err)
 	}

--- a/service/job.go
+++ b/service/job.go
@@ -32,7 +32,7 @@ type Job struct {
 }
 
 func (vs *VaultService) Job() (*Job, error) {
-	vaultClient, err := vs.newClient()
+	vaultClient, err := vs.newUnsealedClient()
 	if err != nil {
 		return nil, maskAny(err)
 	}


### PR DESCRIPTION
For extracting&managing secrets `vault-monkey` now uses the first vault instance that is unsealed.
This prevents issues when one instance is on a machine that is just restarted (leaving its vault instance sealed). In cases like that `vault-monkey` will just use the next instance, greatly reducing the chance of downtime.
